### PR TITLE
fix: filter verlopen bezoeken + Calendar entity

### DIFF
--- a/custom_components/ecare/__init__.py
+++ b/custom_components/ecare/__init__.py
@@ -22,7 +22,7 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "calendar"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/ecare/api.py
+++ b/custom_components/ecare/api.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 import re
 import secrets
+from datetime import datetime, timedelta
 from html.parser import HTMLParser
 from urllib.parse import parse_qs, urlencode, urljoin, urlparse
 
@@ -246,6 +247,7 @@ class EcareAuthClient:
         Geeft een platte lijst van bezoeken: datum, dag, tijd, wie, locatie.
         """
         data = await self._api_post("planning/GetPlanningVanKomendeWeken", access_token)
+        cutoff = datetime.now() - timedelta(hours=2)
         bezoeken = []
         for dag in data.get("Datums", []):
             datum_tekst = dag.get("Datum", {}).get("tekst", "")
@@ -254,11 +256,20 @@ class EcareAuthClient:
             for bezoek in dag.get("Bezoeken", []):
                 if bezoek.get("VandaagGeenZorg"):
                     continue
+                tijd_tekst = bezoek.get("Tijd", {}).get("Tekst", "")
+                # Filter verlopen bezoeken (2 uur na geplande tijd)
+                if datum_iso and tijd_tekst:
+                    try:
+                        bezoek_dt = datetime.strptime(f"{datum_iso} {tijd_tekst}", "%Y-%m-%d %H:%M")
+                        if bezoek_dt < cutoff:
+                            continue
+                    except ValueError:
+                        pass
                 bezoeken.append({
                     "datum":     datum_tekst,
                     "datum_iso": datum_iso,
                     "dag":       dag_naam,
-                    "tijd":      bezoek.get("Tijd", {}).get("Tekst", ""),
+                    "tijd":      tijd_tekst,
                     "wie":       (bezoek.get("Medewerker") or {}).get("WeergaveNaam", ""),
                     "locatie":   bezoek.get("Toelichting", ""),
                 })

--- a/custom_components/ecare/calendar.py
+++ b/custom_components/ecare/calendar.py
@@ -1,0 +1,78 @@
+"""eCare Calendar entity — toont zorgbezoeken in de HA kalender."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import EcareCoordinator
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: EcareCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([EcarePlanningCalendar(coordinator, entry)])
+
+
+class EcarePlanningCalendar(CoordinatorEntity, CalendarEntity):
+    _attr_icon = "mdi:calendar-heart"
+
+    def __init__(self, coordinator: EcareCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_calendar"
+        self._attr_name = "eCare Planning"
+
+    def _bezoeken(self) -> list[dict]:
+        return (self.coordinator.data or {}).get("planning") or []
+
+    @staticmethod
+    def _to_event(bezoek: dict) -> CalendarEvent | None:
+        datum_iso = bezoek.get("datum_iso", "")
+        tijd_tekst = bezoek.get("tijd", "")
+        if not datum_iso or not tijd_tekst:
+            return None
+        try:
+            start = datetime.strptime(f"{datum_iso} {tijd_tekst}", "%Y-%m-%d %H:%M")
+        except ValueError:
+            return None
+        end = start + timedelta(hours=1)
+        wie = bezoek.get("wie", "")
+        locatie = bezoek.get("locatie", "")
+        summary = wie or "Zorgbezoek"
+        return CalendarEvent(
+            start=start,
+            end=end,
+            summary=summary,
+            description=locatie or None,
+            location=locatie or None,
+        )
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Eerstvolgende bezoek (voor het kalender-badge icoontje)."""
+        for bezoek in self._bezoeken():
+            ev = self._to_event(bezoek)
+            if ev:
+                return ev
+        return None
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
+        events = []
+        for bezoek in self._bezoeken():
+            ev = self._to_event(bezoek)
+            if ev and ev.start < end_date and ev.end > start_date:
+                events.append(ev)
+        return events

--- a/custom_components/ecare/manifest.json
+++ b/custom_components/ecare/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecare",
   "name": "eCare Dossier Monitor",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "documentation": "https://github.com/rweijnen/ecare-ha",
   "issue_tracker": "https://github.com/rweijnen/ecare-ha/issues",
   "requirements": [],


### PR DESCRIPTION
Sluit #9 en #10.

## Wijzigingen

- **`api.py`**: `get_planning()` filtert bezoeken die meer dan 2 uur geleden gepland stonden. Een bezoek om 16:15 verdwijnt pas om 18:15 uit de sensor/kalender — tijden zijn bij benadering.
- **`calendar.py`**: Nieuwe `CalendarEntity` die zorgbezoeken toont in de HA-kalender (agenda-weergave). Elk bezoek heeft een duur van 1 uur.
- **`__init__.py`**: `PLATFORMS` uitgebreid met `"calendar"`.
- Versie 0.4.0.