### PR TITLE
fix: herstel integratie (calendar tijdelijk uitgeschakeld)

### DIFF
--- a/custom_components/ecare/__init__.py
+++ b/custom_components/ecare/__init__.py
@@ -22,7 +22,7 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-PLATFORMS = ["sensor", "calendar"]
+PLATFORMS = ["sensor"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/ecare/manifest.json
+++ b/custom_components/ecare/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecare",
   "name": "eCare Dossier Monitor",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "documentation": "https://github.com/rweijnen/ecare-ha",
   "issue_tracker": "https://github.com/rweijnen/ecare-ha/issues",
   "requirements": [],


### PR DESCRIPTION
calendar.py veroorzaakte een import-fout waardoor de gehele integratie niet meer laadde. Dit verwijdert calendar tijdelijk uit PLATFORMS zodat de sensors weer werken.

Versie 0.4.2.